### PR TITLE
fixing compilation error due to addition to uniswapv3 interface

### DIFF
--- a/contracts/core/interfaces/uniswapV3/IUniswapV3Pool.sol
+++ b/contracts/core/interfaces/uniswapV3/IUniswapV3Pool.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+
 pragma solidity ^0.8.0;
 
 interface IUniswapV3Pool {
@@ -9,9 +10,9 @@ interface IUniswapV3Pool {
         uint160 sqrtPriceLimitX96,
         bytes calldata data
     ) external returns (int256 amount0, int256 amount1);
-    
+
     function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external;
-    
+
     function slot0()
         external
         view

--- a/contracts/mocks/MockMargin.sol
+++ b/contracts/mocks/MockMargin.sol
@@ -3,17 +3,16 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../core/interfaces/IAmm.sol";
 
 contract MockMargin  {
+    address public config;
+    address public amm;
+    address public baseToken;
+    address public quoteToken;
+    uint256 public reserve;
 
-
-    address public  config;
-    address public  amm;
-    address public  baseToken;
-    address public  quoteToken;
-    uint256 public  reserve;
     constructor() {
-        
     }
 
     function initialize(
@@ -22,16 +21,15 @@ contract MockMargin  {
         address amm_,
         address config_
     ) external  {
-       
         baseToken = baseToken_;
         quoteToken = quoteToken_;
         amm = amm_;
         config = config_ ;
     }
+
     function netPosition() external view returns (int256 netBasePosition){
         return 2 * 10**18;
     }
-
 
     function deposit(address user, uint256 amount) external  {
         require(msg.sender == amm, "Margin.deposit: REQUIRE_AMM");
@@ -40,9 +38,16 @@ contract MockMargin  {
         require(amount <= balance - reserve, "Margin.deposit: INSUFFICIENT_AMOUNT");
 
         reserve = reserve + amount;
-
-
     }
 
-    
+    // need for testing
+    function swapProxy(
+        address trader,
+        address inputToken,
+        address outputToken,
+        uint256 inputAmount,
+        uint256 outputAmount
+    ) external returns (uint256[2] memory amounts) {
+      IAmm(amm).swap(trader, inputToken, outputToken, inputAmount, outputAmount);
+    }
 }

--- a/contracts/mocks/MockUniswapV3Pool.sol
+++ b/contracts/mocks/MockUniswapV3Pool.sol
@@ -294,6 +294,7 @@ contract MockUniswapV3Pool is IUniswapV3Pool {
         uint160 sqrtPriceLimitX96,
         bytes calldata data
     ) external override returns (int256 amount0, int256 amount1) {
+        // TODO: define the swap behavior of this mock
         amount0 = 0;
         amount1 = 0;
     }

--- a/contracts/mocks/MockUniswapV3Pool.sol
+++ b/contracts/mocks/MockUniswapV3Pool.sol
@@ -286,4 +286,15 @@ contract MockUniswapV3Pool is IUniswapV3Pool {
         uint256 priceX192 = uint256(quoteReserve).mulDiv(2**192, baseReserve);
         return uint160(priceX192.sqrt());
     }
+
+    function swap(
+        address recipient,
+        bool zeroForOne,
+        int256 amountSpecified,
+        uint160 sqrtPriceLimitX96,
+        bytes calldata data
+    ) external override returns (int256 amount0, int256 amount1) {
+        amount0 = 0;
+        amount1 = 0;
+    }
 }

--- a/test/amm.js
+++ b/test/amm.js
@@ -103,9 +103,9 @@ describe("Amm", function () {
         ethers.BigNumber.from("316227766016836933")
       );
     // alice swap in
-    const ammAlice = amm.connect(alice);
+    const marginAlice = margin.connect(alice);
     // alice swap 100AAA to usdt
-    let tx1 = await ammAlice.swap(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("100").mul(exp1), 0);
+    let tx1 = await marginAlice.swapProxy(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("100").mul(exp1), 0);
     const swapRes = await tx1.wait();
     let eventabi = [
       "event Swap(address indexed trader, address indexed inputToken, address indexed outputToken, uint256 inputAmount, uint256 outputAmount);"
@@ -119,7 +119,7 @@ describe("Amm", function () {
     expect(args1.outputAmount).to.equal(9989002);
 
     // alice swap out
-    let tx2 = await ammAlice.swap(alice.address, AAAToken.address, USDT.address, 0, ethers.BigNumber.from("100").mul(exp2));
+    let tx2 = await marginAlice.swapProxy(alice.address, AAAToken.address, USDT.address, 0, ethers.BigNumber.from("100").mul(exp2));
     // alice swap to 100 usdt
     const swapRes2 = await tx2.wait();
     let log2 = iface1.parseLog(swapRes2.logs[1]);
@@ -146,17 +146,17 @@ describe("Amm", function () {
         ethers.BigNumber.from("316227766016836933")
       );
 
-    const ammAlice = amm.connect(alice);
+    const marginAlice = margin.connect(alice);
     // alice swap 1000000AAA to usdt
     // alice swap in
     let price2 = await amm.lastPrice();
 
     // let reserver = await amm.getReserves();
     await expect(
-      ammAlice.swap(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("10000000").mul(exp1), 0)
+      marginAlice.swapProxy(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("10000000").mul(exp1), 0)
     ).to.be.revertedWith("AMM._update: TRADINGSLIPPAGE_TOO_LARGE");
 
-    let tx1 = await ammAlice.swap(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("10000").mul(exp1), 0);
+    let tx1 = await marginAlice.swapProxy(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("10000").mul(exp1), 0);
     const swapRes = await tx1.wait();
     let eventabi = [
       "event Swap(address indexed trader, address indexed inputToken, address indexed outputToken, uint256 inputAmount, uint256 outputAmount);",
@@ -170,7 +170,7 @@ describe("Amm", function () {
     expect(price2).to.equal(price3);
 
     expect(args1.outputAmount).to.equal(989118704);
-    await ammAlice.swap(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("10000").mul(exp1), 0);
+    await marginAlice.swapProxy(alice.address, AAAToken.address, USDT.address, ethers.BigNumber.from("10000").mul(exp1), 0);
 
     let price4 = await amm.lastPrice();
 
@@ -193,11 +193,11 @@ describe("Amm", function () {
         ethers.BigNumber.from("316227766016836933")
       );
 
-    const ammAlice = amm.connect(alice);
+    const marginAlice = margin.connect(alice);
     // alice swap  some AAA to 100000 usdt
     // alice swap out
     await expect(
-      ammAlice.swap(alice.address, AAAToken.address, USDT.address, 0, ethers.BigNumber.from("100000").mul(exp2))
+      marginAlice.swapProxy(alice.address, AAAToken.address, USDT.address, 0, ethers.BigNumber.from("100000").mul(exp2))
     ).to.be.revertedWith("AMM._estimateSwap: INSUFFICIENT_LIQUIDITY");
   });
 });


### PR DESCRIPTION
- fixing compilation error due to addition to uniswapv3 interface
- improving whitespace style in `test/amm.js`
- making tests runnable without modifying onlyMargin decorator
    + now we can simply run `npx hardhat test` and expect all the test to run & pass.

I still see two tests failures, btw:
```
  1) nftSquid contract
       burn  4560 in  0 month:
     Error: VM Exception while processing transaction: reverted with reason string 'GAME_IS_ALREADY_END'
      at NftSquid.getApproved (@openzeppelin/contracts/token/ERC721/ERC721.sol:127)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at runNextTicks (node:internal/process/task_queues:65:3)
      at listOnTimeout (node:internal/timers:536:9)
      at processTimers (node:internal/timers:510:7)
      at HardhatNode._mineBlockWithPendingTxs (node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:1649:23)
      at HardhatNode.mineBlock (node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:458:16)
      at EthModule._sendTransactionAndReturnHash (node_modules/hardhat/src/internal/hardhat-network/provider/modules/eth.ts:1496:18)
      at HardhatNetworkProvider.request (node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:117:18)
      at EthersProviderWrapper.send (node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)

  2) VIPNFT contract
       claim:
     InvalidInputError: Timestamp 1646001383 is lower than or equal to previous block's timestamp 1646029872
      at EvmModule._setNextBlockTimestampAction (node_modules/hardhat/src/internal/hardhat-network/provider/modules/evm.ts:92:13)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at runNextTicks (node:internal/process/task_queues:65:3)
      at listOnTimeout (node:internal/timers:536:9)
      at processTimers (node:internal/timers:510:7)
      at HardhatNetworkProvider.request (node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:117:18)
      at EthersProviderWrapper.send (node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
      at Context.<anonymous> (test/VIPNFT.js:48:5)```